### PR TITLE
e2e: persist session between it blocks

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -8,6 +8,10 @@ module.exports = defineConfig({
   viewportWidth: parseInt(process.env.CYPRESS_VIEWPORT_WIDTH, 10) || 1280,
   viewportHeight: parseInt(process.env.CYPRESS_VIEWPORT_HEIGHT, 10) || 720,
   e2e: {
+    // Same idea as kni-assisted-installer-auto/ui_tests: keep URL, cookies, and SPA state
+    // between `it` blocks instead of resetting the browser each time.
+    // Use before() + cy.ensureLoggedIn() once per top-level describe (not beforeEach).
+    testIsolation: false,
     setupNodeEvents(on, config) {
       on('task', {downloadFile})
     },

--- a/cypress/e2e/device.cy.js
+++ b/cypress/e2e/device.cy.js
@@ -1,8 +1,9 @@
 import { devicesPage } from '../views/devicesPage'
 
 describe('Device Management', () => {
-  beforeEach(() => {
-    cy.login(`${Cypress.env('host')}`, `${Cypress.env('auth')}`, `${Cypress.env('username')}`, `${Cypress.env('password')}`)
+  // One login + visit per spec file; later tests reuse the same tab (testIsolation: false).
+  before(() => {
+    cy.ensureLoggedIn()
   })
 
   describe('Approve device – Alias validation (negative)', () => {

--- a/cypress/e2e/fleet.cy.js
+++ b/cypress/e2e/fleet.cy.js
@@ -2,8 +2,8 @@ import { fleetsPage } from '../views/fleetsPage'
 import { repositoriesPage } from '../views/repositoriesPage'
 
 describe('Fleet Management', () => {
-  beforeEach(() => {
-    cy.login(`${Cypress.env('host')}`, `${Cypress.env('auth')}`, `${Cypress.env('username')}`, `${Cypress.env('password')}`)
+  before(() => {
+    cy.ensureLoggedIn()
   })
 
   it('Should create a fleet', () => {

--- a/cypress/e2e/repository.cy.js
+++ b/cypress/e2e/repository.cy.js
@@ -1,8 +1,8 @@
 import { repositoriesPage } from '../views/repositoriesPage'
 
 describe('Repository Management', () => {
-  beforeEach(() => {
-    cy.login(`${Cypress.env('host')}`, `${Cypress.env('auth')}`, `${Cypress.env('username')}`, `${Cypress.env('password')}`)
+  before(() => {
+    cy.ensureLoggedIn()
   })
 
   /* it('Should create a repository', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -3,7 +3,7 @@ require('cypress-downloadfile/lib/downloadFileCommand')
 /**
  * Dismiss clusters onboarding modal if it appears (used after login and after session restore).
  */
-const tryCloseOnboardingModal = (attempt = 1, maxRetries = 25, retryDelay = 2000) => {
+const tryCloseOnboardingModal = (attempt = 1, maxRetries = 15, retryDelay = 2000) => {
   cy.get('body').then(($body) => {
     const $btn = $body.find('[data-ouia-component-id="clustersOnboardingModal-ModalBoxCloseButton"]')
     if ($btn.length > 0) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,8 +1,22 @@
 require('cypress-downloadfile/lib/downloadFileCommand')
 
+/**
+ * Dismiss clusters onboarding modal if it appears (used after login and after session restore).
+ */
+const tryCloseOnboardingModal = (attempt = 1, maxRetries = 25, retryDelay = 2000) => {
+  cy.get('body').then(($body) => {
+    const $btn = $body.find('[data-ouia-component-id="clustersOnboardingModal-ModalBoxCloseButton"]')
+    if ($btn.length > 0) {
+      cy.get('[data-ouia-component-id="clustersOnboardingModal-ModalBoxCloseButton"]').click()
+    } else if (attempt < maxRetries) {
+      cy.wait(retryDelay)
+      tryCloseOnboardingModal(attempt + 1, maxRetries, retryDelay)
+    }
+  })
+}
 
 Cypress.Commands.add('login', (url=`${Cypress.env('host')}`, auth=`${Cypress.env('auth')}`, user=`${Cypress.env('username')}`, password=`${Cypress.env('password')}`) => {
-    cy.visit(url)
+    cy.visit(url, { timeout: 60000, retryOnStatusCodeFailure: true })
     cy.origin(auth, { args: { username: user, password: password } }, ({ username, password }) => {
         //cy.get('.pf-c-button', { timeout: 60000 })
         cy.get('.pf-v6-c-button').contains('kube:admin').click()
@@ -16,19 +30,29 @@ Cypress.Commands.add('login', (url=`${Cypress.env('host')}`, auth=`${Cypress.env
         cy.get('#inputPassword').should('have.value', password)
         cy.get('#co-login-button').click()
       })
-    const tryCloseOnboardingModal = (attempt = 1, maxRetries = 15, retryDelay = 2000) => {
-      cy.get('body').then(($body) => {
-        const $btn = $body.find('[data-ouia-component-id="clustersOnboardingModal-ModalBoxCloseButton"]')
-        if ($btn.length > 0) {
-          cy.get('[data-ouia-component-id="clustersOnboardingModal-ModalBoxCloseButton"]').click()
-        } else if (attempt < maxRetries) {
-          cy.wait(retryDelay)
-          tryCloseOnboardingModal(attempt + 1, maxRetries, retryDelay)
-        }
-      })
-    }
     tryCloseOnboardingModal()
     cy.url().should('include', `${Cypress.env('host')}`)    
+})
+
+/**
+ * Restores a cached browser session after the first successful login.
+ * Use once per spec in before() with testIsolation: false so later `it` blocks reuse the same tab.
+ * Session key includes host/auth/user so changing env invalidates the cache.
+ */
+Cypress.Commands.add('ensureLoggedIn', () => {
+  const host = Cypress.env('host')
+  const auth = Cypress.env('auth')
+  const user = Cypress.env('username')
+  const password = Cypress.env('password')
+  cy.session(
+    ['openshift-console', host, auth, user],
+    () => {
+      cy.login(host, auth, user, password)
+    }
+  )
+  cy.visit(host, { timeout: 60000, retryOnStatusCodeFailure: true })
+  tryCloseOnboardingModal()
+  cy.url().should('include', host)
 })
 
 Cypress.Commands.add('downloadClifile', (platform = `${Cypress.env('platform')}`, arch = `${Cypress.env('arch')}`) => {

--- a/cypress/views/common.js
+++ b/cypress/views/common.js
@@ -1,6 +1,10 @@
 /**
  * Common utilities for test operations
  */
+
+/** True after org selection was handled or confirmed absent — only run once per spec (first navigateTo). */
+let organizationSelectionHandled = false
+
 export const common = {
   /**
    * Navigate to a page (supports both ACM multi-level nav and flat nav).
@@ -37,29 +41,41 @@ export const common = {
   },
 
   /**
-   * Select organization if the selection page appears
+   * Select organization if the selection page appears.
+   * Runs only the first time in a spec (first `navigateTo`); later calls are no-ops.
    */
   selectOrganizationIfNeeded: (orgName = 'Default', maxRetries = 10, retryDelay = 1000) => {
+    if (organizationSelectionHandled) {
+      cy.log('Organization selection already handled this run, skipping')
+      return
+    }
+
+    const markHandled = () => {
+      organizationSelectionHandled = true
+    }
+
     const checkForOrgSelection = (attempt = 1) => {
       cy.log(`Checking for organization selection page (attempt ${attempt}/${maxRetries})`)
-      
+
       cy.wait(retryDelay)
-      
+
       cy.get('body').then(($body) => {
         if ($body.text().includes('Select Organization')) {
           cy.log(`Organization selection page detected, selecting ${orgName}`)
           cy.contains(orgName).click()
           cy.contains('button', 'Continue').click()
           cy.get('.pf-v6-c-page', { timeout: 30000 }).should('exist')
+          cy.then(markHandled)
         } else if (attempt < maxRetries) {
           cy.log(`Organization selection not found yet, retrying...`)
           checkForOrgSelection(attempt + 1)
         } else {
           cy.log('No organization selection page detected after all retries, continuing...')
+          markHandled()
         }
       })
     }
-    
+
     checkForOrgSelection()
   },
 }


### PR DESCRIPTION
- testIsolation: false + before()/ensureLoggedIn per spec
- cy.session caches login; revisit host after restore
- Org selection runs once per spec when reusing browser state

Made-with: Cursor