### PR TITLE
feat: add createRepositoryWithCredentials and flightctl-repo-with-wri…

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -43,6 +43,12 @@ module.exports = defineConfig({
     yaml: process.env.YAML || '/demos/basic-nginx-demo/deployment/fleet.yaml',
     newyaml: process.env.NEWYAML || '/demos/quadlet-wordpress-demo/deployment/fleet.yaml',
     repositoryname: process.env.REPOSITORYNAME || 'test-repository',
+    flightctlRepoWithWriteName:     process.env.FLIGHTCTL_REPO_WITH_WRITE_NAME     || 'flightctl-repo',
+    flightctlRepoWithWriteHostName: process.env.FLIGHTCTL_REPO_WITH_WRITE_HOSTNAME || '',
+    flightctlRepoWithWriteUrl:      process.env.FLIGHTCTL_REPO_WITH_WRITE_URL      || '',
+    flightctlRepoWithWritePath:     process.env.FLIGHTCTL_REPO_WITH_WRITE_PATH     || '',
+    flightctlRepoWithWriteUsername: process.env.FLIGHTCTL_REPO_WITH_WRITE_USERNAME || '',
+    flightctlRepoWithWritePassword: process.env.FLIGHTCTL_REPO_WITH_WRITE_PASSWORD || '',
     resourcename: process.env.RESOURCENAME || 'base/fedora-bootc/deploy/fleet.yaml',
     useAcmNavigation: process.env.CYPRESS_USE_ACM_NAVIGATION !== 'false',
     // auth-provider-login.cy.js: full authorize URL from `flightctl login --web --no-browser` output

--- a/cypress/e2e/buildImagePage.cy.js
+++ b/cypress/e2e/buildImagePage.cy.js
@@ -1,0 +1,199 @@
+import { buildImagePage } from '../views/buildImagePage'
+
+const BUILD_NAME        = 'new-build-flightctl'
+const SOURCE_IMAGE_NAME = 'centos-bootc/centos-bootc'
+const SOURCE_IMAGE_TAG  = 'stream10'
+const OUTPUT_IMAGE_TAG  = '1.0.0'
+const README_TEXT       = 'TestTest'
+
+describe('Build Image Page', () => {
+  before(() => {
+    // The OpenShift/ACM console fires background unhandled promise rejections during
+    // navigation (e.g. multicloud cluster API calls). Letting Cypress surface those as
+    // test failures would abort the before-all hook and skip the entire suite.
+    // Returning false tells Cypress not to fail on uncaught app-level exceptions.
+    Cypress.on('uncaught:exception', () => false)
+    cy.ensureLoggedIn()
+  })
+
+  afterEach(function () {
+    if (this.currentTest.state === 'failed') {
+      Cypress.runner.stop()
+    }
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Pre-requisite: Create OCI repository used across all wizard steps
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Create OCI Repository (pre-requisite)', () => {
+    it('Should navigate to Repositories', () => {
+      buildImagePage.navigateToRepositories()
+    })
+
+    it('Should open the Create Repository form', () => {
+      buildImagePage.openCreateRepositoryForm()
+    })
+
+    it('Should type the repository name', () => {
+      buildImagePage.typeRepositoryName(Cypress.env('flightctlRepoWithWriteName'))
+    })
+
+    it('Should switch to "Use OCI registry" (resets the hostname field)', () => {
+      buildImagePage.selectOciRegistryType()
+    })
+
+    it('Should select "Read and write" access mode', () => {
+      buildImagePage.selectReadAndWriteAccessMode()
+    })
+
+    it('Should type the registry hostname', () => {
+      buildImagePage.typeRegistryHostname(Cypress.env('flightctlRepoWithWriteHostName'))
+    })
+
+    it('Should enable "Use advanced configurations"', () => {
+      buildImagePage.enableAdvancedConfigurations()
+    })
+
+    it('Should check "Basic authentication"', () => {
+      buildImagePage.enableBasicAuthentication()
+    })
+
+    it('Should fill in username', () => {
+      buildImagePage.typeUsername(Cypress.env('flightctlRepoWithWriteUsername'))
+    })
+
+    it('Should fill in password', () => {
+      buildImagePage.typePassword(Cypress.env('flightctlRepoWithWritePassword'))
+    })
+
+    it('Should submit the repository and wait for Accessible status', () => {
+      buildImagePage.submitRepositoryAndWaitForAccessible()
+    })
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Wizard Step 1 — Base image
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Build New Image — Step 1: Base image', () => {
+    it('Should navigate to Image builds', () => {
+      buildImagePage.navigateToImageBuilds()
+    })
+
+    it('Should click "Build new image"', () => {
+      buildImagePage.clickBuildNewImage()
+    })
+
+    it('Should type the build name', () => {
+      buildImagePage.typeBuildName(BUILD_NAME)
+    })
+
+    it('Should select the source repository created in the pre-requisite step', () => {
+      buildImagePage.selectSourceRepository(Cypress.env('flightctlRepoWithWriteName'))
+    })
+
+    it('Should type the image name', () => {
+      buildImagePage.typeSourceImageName(SOURCE_IMAGE_NAME)
+    })
+
+    it('Should type the image tag', () => {
+      buildImagePage.typeSourceImageTag(SOURCE_IMAGE_TAG)
+    })
+
+    it('Should wait for "Accessible" status on the Image reference URL', () => {
+      buildImagePage.waitForImageAccessible()
+    })
+
+    it('Should click Next to proceed to Image output', () => {
+      buildImagePage.clickNext()
+    })
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Wizard Step 2 — Image output
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Build New Image — Step 2: Image output', () => {
+    it('Should select the target repository (same as the one created in pre-requisite)', () => {
+      buildImagePage.selectTargetRepository(Cypress.env('flightctlRepoWithWriteName'))
+    })
+
+    it('Should clear and type the image name from env', () => {
+      buildImagePage.typeOutputImageName(Cypress.env('flightctlRepoWithWritePath'))
+    })
+
+    it('Should clear and type the image tag', () => {
+      buildImagePage.typeOutputImageTag(OUTPUT_IMAGE_TAG)
+    })
+
+    it('Should click Next to proceed to Registration', () => {
+      buildImagePage.clickNext()
+    })
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Wizard Step 3 — Registration
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Build New Image — Step 3: Registration', () => {
+    it('Should leave all registration defaults and click Next', () => {
+      buildImagePage.clickNext()
+    })
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Wizard Step 4 — Software Catalog
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Build New Image — Step 4: Software Catalog', () => {
+    it('Should verify "Add to the software catalog testing channel upon successful build" is checked by default', () => {
+      buildImagePage.verifySoftwareCatalogCheckboxChecked()
+    })
+
+    it('Should type the image promotion name (build name + "-build" suffix)', () => {
+      buildImagePage.typeImagePromotionName(`${BUILD_NAME}-build`)
+    })
+
+    it('Should open the Catalog dropdown and select "Default"', () => {
+      buildImagePage.selectDefaultCatalog()
+    })
+
+    it('Should select "New catalog item"', () => {
+      buildImagePage.selectNewCatalogItem()
+    })
+
+    it('Should type the catalog item name (build name + "-cin" suffix)', () => {
+      buildImagePage.typeCatalogItemName(`${BUILD_NAME}-cin`)
+    })
+
+    it('Should type the version', () => {
+      buildImagePage.typeVersion(OUTPUT_IMAGE_TAG)
+    })
+
+    it('Should type the readme text', () => {
+      buildImagePage.typeReadme(README_TEXT)
+    })
+
+    it('Should click Next to proceed to Review', () => {
+      buildImagePage.clickNext()
+    })
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Wizard Step 5 — Review
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Build New Image — Step 5: Review', () => {
+    it('Should click "Build image" to submit', () => {
+      buildImagePage.clickBuildImage()
+    })
+  })
+
+  // ══════════════════════════════════════════════════════════════════════════════
+  // Post-build: wait for the build to complete and be published to Software Catalog
+  // ══════════════════════════════════════════════════════════════════════════════
+  describe('Image build completion', () => {
+    it('Should wait for Build status to be "Complete"', () => {
+      buildImagePage.waitForBuildStatusComplete(BUILD_NAME)
+    })
+
+    it('Should wait for Promotion status to be "Completed"', () => {
+      buildImagePage.waitForPromotionStatusCompleted(BUILD_NAME)
+    })
+  })
+})

--- a/cypress/views/buildImagePage.js
+++ b/cypress/views/buildImagePage.js
@@ -1,0 +1,229 @@
+import { common } from './common'
+
+// ─── Internal helpers (not exported) ─────────────────────────────────────────
+
+/** Click a PatternFly radio or checkbox by its visible label text. */
+const clickLabel = (labelText) =>
+  cy.contains('label', labelText).should('be.visible').click()
+
+/**
+ * Return the first <input> or <textarea> inside the PatternFly form group
+ * whose heading contains the given text.
+ */
+const inputInGroup = (labelText) =>
+  cy
+    .contains('.pf-v6-c-form__group-label', labelText)
+    .closest('.pf-v6-c-form__group')
+    .find('input, textarea')
+    .first()
+
+/**
+ * Open a PatternFly Select/MenuToggle inside the form group whose heading
+ * contains labelText, then click the matching option.
+ */
+const selectInGroup = (labelText, optionText) => {
+  cy.contains('.pf-v6-c-form__group-label', labelText)
+    .closest('.pf-v6-c-form__group')
+    .find('button[aria-haspopup="listbox"], button.pf-v6-c-menu-toggle')
+    .should('be.visible')
+    .click()
+  cy.contains('.pf-v6-c-menu__item-text, li', optionText).should('be.visible').click()
+}
+
+// ─── Page object ─────────────────────────────────────────────────────────────
+
+export const buildImagePage = {
+
+  // ── OCI Repository creation ────────────────────────────────────────────────
+
+  navigateToRepositories: () => {
+    common.navigateTo('Repositories')
+  },
+
+  openCreateRepositoryForm: () => {
+    // The toolbar may render separate Git and OCI create buttons under the same testid.
+    // Use first() to always target the primary (first) button; revisit if a dedicated
+    // OCI testid (e.g. toolbar-create-oci-repository) is added to the UI.
+    cy.get('[data-testid="toolbar-create-repository"]').first().should('be.visible').click()
+    cy.get('[data-testid="rich-validation-field-name"]').should('be.visible')
+  },
+
+  typeRepositoryName: (name) => {
+    cy.wait(100)
+    cy.get('[data-testid="rich-validation-field-name"]').should('be.visible').type(name)
+    cy.get('[data-testid="rich-validation-field-name"]').should('have.value', name)
+  },
+
+  selectOciRegistryType: () => {
+    clickLabel('Use OCI registry')
+  },
+
+  selectReadAndWriteAccessMode: () => {
+    cy.get('#radiofield-oci-access-readwrite').check({ force: true })
+  },
+
+  typeRegistryHostname: (hostname) => {
+    // The hostname field is reset when the type is switched to OCI — always type after switching.
+    // The field is labelled "Registry hostname"; fall back to data-testid variants if the label
+    // selector ever changes.
+    cy.get('body').then(($body) => {
+      const byTestId = $body.find('[data-testid="textfield-url"], [data-testid="textfield-hostname"]')
+      if (byTestId.length) {
+        cy.wrap(byTestId.first()).should('be.visible').clear().type(hostname)
+        cy.wrap(byTestId.first()).should('have.value', hostname)
+      } else {
+        inputInGroup('Registry hostname').should('be.visible').clear().type(hostname)
+        inputInGroup('Registry hostname').should('have.value', hostname)
+      }
+    })
+  },
+
+  enableAdvancedConfigurations: () => {
+    cy.get('body').then(($body) => {
+      const checkbox = $body.find('#use-advanced-configurations')
+      if (checkbox.length) {
+        cy.wrap(checkbox).check({ force: true })
+      } else {
+        clickLabel('Use advanced configurations')
+      }
+    })
+  },
+
+  enableBasicAuthentication: () => {
+    cy.get('body').then(($body) => {
+      const checkbox = $body.find('input[id*="basic-auth"], input[id*="basicAuth"]')
+      if (checkbox.length) {
+        cy.wrap(checkbox.first()).check({ force: true })
+      } else {
+        clickLabel('Basic authentication')
+      }
+    })
+  },
+
+  typeUsername: (username) => {
+    cy.get('[data-testid="textfield-ociConfig.ociAuth.username"]').scrollIntoView().should('be.visible').type(username)
+    cy.get('[data-testid="textfield-ociConfig.ociAuth.username"]').should('have.value', username)
+  },
+
+  typePassword: (password) => {
+    cy.get('[data-testid="textfield-ociConfig.ociAuth.password"]').should('be.visible').type(password)
+  },
+
+  submitRepositoryAndWaitForAccessible: () => {
+    cy.get('[data-testid="repository-form-submit"]').should('be.visible').click()
+    //cy.get('[data-testid="repository-details-sync-status"]', { timeout: 30000 })
+    //  .should('contain', 'Accessible')
+  },
+
+  // ── Wizard entry ───────────────────────────────────────────────────────────
+
+  navigateToImageBuilds: () => {
+    common.navigateTo('Image builds')
+  },
+
+  clickBuildNewImage: () => {
+    cy.contains('button', 'Build new image').should('be.visible').click()
+    cy.contains('Build new image').should('be.visible')
+  },
+
+  // ── Step 1: Base image ─────────────────────────────────────────────────────
+
+  typeBuildName: (buildName) => {
+    inputInGroup('Build name').should('be.visible').type(buildName)
+    inputInGroup('Build name').should('have.value', buildName)
+  },
+
+  selectSourceRepository: (repoName) => {
+    selectInGroup('Source repository', repoName)
+  },
+
+  typeSourceImageName: (imageName) => {
+    inputInGroup('Image name').should('be.visible').clear().type(imageName)
+    inputInGroup('Image name').should('have.value', imageName)
+  },
+
+  typeSourceImageTag: (tag) => {
+    inputInGroup('Image tag').should('be.visible').clear().type(tag)
+    inputInGroup('Image tag').should('have.value', tag)
+  },
+
+  waitForImageAccessible: () => {
+    cy.contains('Accessible', { timeout: 30000 }).should('be.visible')
+  },
+
+  clickNext: () => {
+    cy.contains('button', 'Next').should('be.visible').click()
+  },
+
+  // ── Step 2: Image output ───────────────────────────────────────────────────
+
+  selectTargetRepository: (repoName) => {
+    selectInGroup('Target repository', repoName)
+  },
+
+  typeOutputImageName: (imageName) => {
+    inputInGroup('Image name').should('be.visible').clear().type(imageName)
+    inputInGroup('Image name').should('have.value', imageName)
+  },
+
+  typeOutputImageTag: (tag) => {
+    inputInGroup('Image tag').should('be.visible').clear().type(tag)
+    inputInGroup('Image tag').should('have.value', tag)
+  },
+
+  // ── Step 4: Software Catalog ───────────────────────────────────────────────
+
+  verifySoftwareCatalogCheckboxChecked: () => {
+    cy.get('#checkboxfield-promoteToCatalog').should('be.checked')
+  },
+
+  typeImagePromotionName: (name) => {
+    inputInGroup('Image Promotion name').should('be.visible').type(name)
+    inputInGroup('Image Promotion name').should('have.value', name)
+  },
+
+  selectDefaultCatalog: () => {
+    cy.get('#selectfield-catalog-menu').should('be.visible').click()
+    cy.contains('.pf-v6-c-menu__item-text', 'Default').should('be.visible').click()
+  },
+
+  selectNewCatalogItem: () => {
+    clickLabel('New catalog item')
+  },
+
+  typeCatalogItemName: (name) => {
+    inputInGroup('Catalog item name').should('be.visible').type(name)
+    inputInGroup('Catalog item name').should('have.value', name)
+  },
+
+  typeVersion: (version) => {
+    inputInGroup('Version').should('be.visible').type(version)
+    inputInGroup('Version').should('have.value', version)
+  },
+
+  typeReadme: (text) => {
+    inputInGroup('Readme').should('be.visible').type(text)
+  },
+
+  // ── Step 5: Review ────────────────────────────────────────────────────────
+
+  clickBuildImage: () => {
+    cy.get('[data-testid="wizard-save-button"]').should('be.visible').click()
+  },
+
+  // ── Post-build: status polling on the Image builds list ───────────────────
+
+  waitForBuildStatusComplete: (buildName, timeout = 600000) => {
+    cy.contains('a', buildName, { timeout })
+      .closest('tr')
+      .find('[data-label="Build status"]', { timeout })
+      .should('contain', 'Complete')
+  },
+
+  waitForPromotionStatusCompleted: (buildName, timeout = 300000) => {
+    cy.contains('a', buildName, { timeout })
+      .closest('tr')
+      .find('[data-label="Promotion status"]', { timeout })
+      .should('contain', 'Completed')
+  },
+}


### PR DESCRIPTION
…te env vars

Adds four env vars (name, url, username, password) under the flightctl-repo-with-write prefix to cypress.config.js, and a new createRepositoryWithCredentials() method to repositoriesPage.js that fills in the HTTP-credential fields of the create-repository form.