### PR TITLE
refactor: replace fragile CSS selectors with data-testid in fleet, re…

### DIFF
--- a/cypress/views/downloadsPage.js
+++ b/cypress/views/downloadsPage.js
@@ -38,7 +38,12 @@ const ARTIFACT_BY_PLATFORM = {
 
 export const downloadsPage = {
   openCommandLineTools() {
-    cy.get('button[aria-label="Help menu"]').click().should('be.visible')
+    // standalone UI: FlightCtl's own help menu toggle (data-testid only present in standalone app)
+    // OCP plugin: the OCP shell renders the help button with aria-label="Help menu"
+    const helpMenuSelector = Cypress.env('useAcmNavigation')
+      ? 'button[aria-label="Help menu"]'
+      : '[data-testid="masthead-help-menu"]'
+    cy.get(helpMenuSelector).click().should('be.visible')
     cy.contains('Command Line Tools').click()
     cy.url({ timeout: 30000 }).should('include', 'command-line-tools')
   },

--- a/cypress/views/fleetsPage.js
+++ b/cypress/views/fleetsPage.js
@@ -20,9 +20,8 @@ export const fleetsPage = {
    */
   openCreateFleetWizard: () => {
     common.navigateTo('Fleets')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(1) > .pf-v6-c-button').should('exist')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(1) > .pf-v6-c-button').should('be.visible')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(1) > .pf-v6-c-button').click()
+    cy.get('[data-testid="toolbar-create-fleet"]', { timeout: 10000 }).first().should('be.visible')
+    cy.get('[data-testid="toolbar-create-fleet"]').first().click()
     cy.get('[data-testid="rich-validation-field-name"]').should('be.visible')
   },
 
@@ -74,9 +73,8 @@ export const fleetsPage = {
   createFleet: (img = Cypress.env('image'), fleetname = Cypress.env('fleetname')) => {
     common.navigateTo('Fleets')
 
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(1) > .pf-v6-c-button').should('exist')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(1) > .pf-v6-c-button').should('be.visible')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(1) > .pf-v6-c-button').click()
+    cy.get('[data-testid="toolbar-create-fleet"]', { timeout: 10000 }).first().should('be.visible')
+    cy.get('[data-testid="toolbar-create-fleet"]').first().click()
     cy.get('[data-testid="rich-validation-field-name"]').should('be.visible')
     cy.get('[data-testid="rich-validation-field-name"]').type(fleetname)
     cy.get('[data-testid="rich-validation-field-name"]').should('have.value', 'test-fleet')
@@ -96,11 +94,8 @@ export const fleetsPage = {
   editFleet: (fleetname = Cypress.env('fleetname'), img1 = Cypress.env('newimage')) => {
     common.navigateTo('Fleets')
     
-    cy.get('[data-label="Name"]').contains(fleetname)
-    cy.get('.pf-v6-c-table__action > .pf-v6-c-menu-toggle').click()
-    cy.get('td.pf-v6-c-table__td').then($cells => cy.wrap($cells.eq(-1)))
-    cy.get('.pf-v6-c-table__action > .pf-v6-c-menu-toggle').should('be.visible')
-    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-2"] > .pf-v6-c-menu__item > .pf-v6-c-menu__item-main > .pf-v6-c-menu__item-text').click()
+    cy.get(`[data-testid="fleet-row-actions-${fleetname}"] .pf-v6-c-menu-toggle`).should('be.visible').click()
+    cy.contains('.pf-v6-c-menu__item-text', 'Edit fleet configurations').should('be.visible').click()
     cy.get(':nth-child(1) > .pf-v6-c-form__group-label > .pf-v6-c-form__label > .pf-v6-c-form__label-text').should('contain', 'Fleet name')
     cy.get('[data-testid="wizard-next-button"]').click()
     cy.get('[data-testid="textfield-osImage"]').should('be.visible')
@@ -121,10 +116,10 @@ export const fleetsPage = {
     
     cy.get('[data-label="Name"]').contains(fleetname)
     cy.get('.pf-v6-c-table__tbody > .pf-v6-c-table__tr > .pf-v6-c-table__check > label > input').click()
-    cy.get('button.pf-v6-c-button.pf-m-secondary').contains('Delete fleets').should('be.visible')
-    cy.get('button.pf-v6-c-button.pf-m-secondary').contains('Delete fleets').click()
-    cy.get('.pf-m-danger').should('be.visible')
-    cy.get('.pf-m-danger').click()
+    cy.get('[data-testid="toolbar-delete-fleets"]').should('be.visible')
+    cy.get('[data-testid="toolbar-delete-fleets"]').click()
+    cy.get('[data-testid="modal-delete-fleets-confirm"]').should('be.visible')
+    cy.get('[data-testid="modal-delete-fleets-confirm"]').click()
   },
 
   /**
@@ -133,9 +128,8 @@ export const fleetsPage = {
   importFleet: (repo = Cypress.env('repository'), fleetname = Cypress.env('fleetname'), resource = Cypress.env('resource'), resourcename = Cypress.env('resourcename'), revision = Cypress.env('revision')) => {
     common.navigateTo('Fleets')
     
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(2) > .pf-v6-c-button').should('exist')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(2) > .pf-v6-c-button').should('be.visible')
-    cy.get(':nth-child(2) > .pf-v6-l-split > :nth-child(2) > .pf-v6-c-button').click()
+    cy.get('[data-testid="toolbar-import-fleets"]', { timeout: 10000 }).first().should('be.visible')
+    cy.get('[data-testid="toolbar-import-fleets"]').first().click()
     cy.get('[data-testid="rich-validation-field-name"]').type(fleetname)
     cy.get('[data-testid="textfield-url"]').type(repo)
     cy.get('[data-testid="wizard-next-button"]').click()

--- a/cypress/views/repositoriesPage.js
+++ b/cypress/views/repositoriesPage.js
@@ -110,7 +110,7 @@ export const repositoriesPage = {
     cy.get('[data-testid="rich-validation-field-name"]').clear().type('valid-repo-name')
     cy.get('[data-testid="textfield-url"]').clear().type(validUrl)
     cy.get('[data-testid="textfield-url"]').should('have.value', validUrl)
-    cy.get('#use-resource-syncs').then(($cb) => {
+    cy.get('[data-testid="repository-form-use-resource-syncs"]').then(($cb) => {
       if (!$cb.is(':checked')) {
         cy.wrap($cb).check({ force: true })
       }
@@ -152,7 +152,7 @@ export const repositoriesPage = {
     cy.get('[data-testid="rich-validation-field-name"]').should('be.visible')
     cy.get('[data-testid="rich-validation-field-name"]').type('test-repository')
     cy.get('[data-testid="rich-validation-field-name"]').should('have.value', 'test-repository')
-    cy.get('#use-resource-syncs').should('be.visible')
+    cy.get('[data-testid="repository-form-use-resource-syncs"]').should('be.visible')
     cy.get('[data-testid="textfield-url"]').type(repo)
     cy.get('[data-testid="textfield-url"]').should('have.value', repo)
     cy.get('.pf-v6-c-form__section').should('be.visible')
@@ -160,7 +160,7 @@ export const repositoriesPage = {
     cy.get('[data-testid="textfield-resourceSyncs[0].targetRevision"]').type(revision)
     cy.get('[data-testid="textfield-resourceSyncs[0].path"]').type(resource)
     cy.get('[data-testid="repository-form-submit"]').click()
-    cy.get('.pf-v6-c-description-list__text > .pf-v6-l-flex > :nth-child(2)', { timeout: 100000 }).should('contain', 'Accessible')
+    cy.get('[data-testid="repository-details-sync-status"]', { timeout: 100000 }).should('contain', 'Accessible')
   },
 
   /**


### PR DESCRIPTION
…po, and downloads views

Replace nth-child/class/OUIA CSS selectors with the stable data-testid attributes already present in the flightctl-ui source:
- fleetsPage: toolbar-create-fleet (.first() for empty-state duplicate), fleet-row-actions, toolbar-import-fleets (.first()), toolbar-delete-fleets, modal-delete-fleets-confirm
- downloadsPage: masthead-help-menu
- repositoriesPage: repository-form-use-resource-syncs, repository-details-sync-status