### PR TITLE
feat: add Software Catalog deploy-to-fleet E2E test

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -43,6 +43,10 @@ module.exports = defineConfig({
     yaml: process.env.YAML || '/demos/basic-nginx-demo/deployment/fleet.yaml',
     newyaml: process.env.NEWYAML || '/demos/quadlet-wordpress-demo/deployment/fleet.yaml',
     repositoryname: process.env.REPOSITORYNAME || 'test-repository',
+    buildName: process.env.BUILD_NAME || 'new-build-flightctl',
+    // Set to true (CYPRESS_SKIP_SIMULATOR=true) when running the device simulator manually.
+    // Skips all simulator start/stop/wait/cleanup tasks in softwareCatalogPage.cy.js.
+    skipSimulator: process.env.CYPRESS_SKIP_SIMULATOR === 'true' || false,
     flightctlRepoWithWriteName:     process.env.FLIGHTCTL_REPO_WITH_WRITE_NAME     || 'flightctl-repo',
     flightctlRepoWithWriteHostName: process.env.FLIGHTCTL_REPO_WITH_WRITE_HOSTNAME || '',
     flightctlRepoWithWriteUrl:      process.env.FLIGHTCTL_REPO_WITH_WRITE_URL      || '',

--- a/cypress/e2e/buildImagePage.cy.js
+++ b/cypress/e2e/buildImagePage.cy.js
@@ -1,6 +1,6 @@
 import { buildImagePage } from '../views/buildImagePage'
 
-const BUILD_NAME        = 'new-build-flightctl'
+const BUILD_NAME        = Cypress.env('buildName') || 'new-build-flightctl'
 const SOURCE_IMAGE_NAME = 'centos-bootc/centos-bootc'
 const SOURCE_IMAGE_TAG  = 'stream10'
 const OUTPUT_IMAGE_TAG  = '1.0.0'

--- a/cypress/e2e/softwareCatalogPage.cy.js
+++ b/cypress/e2e/softwareCatalogPage.cy.js
@@ -1,0 +1,127 @@
+import {
+  softwareCatalogPage,
+  getCatalogItemName,
+  CATALOG_FLEET_NAME,
+  CATALOG_FLEET_LABEL_TEXT,
+} from '../views/softwareCatalogPage'
+
+describe('Software Catalog – Deploy to fleet', () => {
+  before(() => {
+    Cypress.on('uncaught:exception', () => false)
+    cy.ensureLoggedIn()
+  })
+
+  afterEach(function () {
+    if (this.currentTest.state === 'failed') {
+      Cypress.runner.stop()
+    }
+  })
+
+  // ════════════════════════════════════════════════════════════════════════════
+  // Pre-requisite: spin up 5 simulated devices belonging to simulator-disk-monitoring
+  //
+  // Set CYPRESS_SKIP_SIMULATOR=true (or skipSimulator: true in cypress.config.js)
+  // to skip all simulator lifecycle tasks when running the simulator manually.
+  // ════════════════════════════════════════════════════════════════════════════
+  describe(`Device simulator – ${CATALOG_FLEET_NAME} (5 devices)`, () => {
+    before(() => {
+      if (Cypress.env('skipSimulator')) {
+        cy.log('skipSimulator=true — skipping simulator start and fleet setup')
+        return
+      }
+      cy.task('scaleFleetEnsureExists', {
+        fleetName: CATALOG_FLEET_NAME,
+        selectorKey: 'fleet',
+        selectorValue: CATALOG_FLEET_NAME,
+      })
+      cy.task('scaleFleetSimulatorStart', {
+        count: 5,
+        label: CATALOG_FLEET_LABEL_TEXT,
+      })
+      cy.task(
+        'scaleFleetSimulatorWaitForDevices',
+        {
+          expected: 5,
+          labelSelector: CATALOG_FLEET_LABEL_TEXT,
+          timeoutMs: 300000,
+          pollMs: 5000,
+          settleMs: 10000,
+        },
+        { timeout: 330000 },
+      )
+    })
+
+    after(() => {
+      if (Cypress.env('skipSimulator')) {
+        cy.log('skipSimulator=true — skipping simulator stop and fleet cleanup')
+        return
+      }
+      cy.task('scaleFleetSimulatorStop')
+      cy.task('scaleFleetCleanup', {
+        fleetName: CATALOG_FLEET_NAME,
+        labelSelector: CATALOG_FLEET_LABEL_TEXT,
+      })
+    })
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Deploy catalog item to the fleet
+    // ──────────────────────────────────────────────────────────────────────────
+    describe('Open Software Catalog and select the published catalog item', () => {
+      it('Should navigate to Software Catalog', () => {
+        softwareCatalogPage.navigateTo()
+      })
+
+      it('Should select the catalog item published by the build image', () => {
+        softwareCatalogPage.selectCatalogItem(getCatalogItemName())
+      })
+
+      it('Should click Deploy in the catalog item details drawer', () => {
+        softwareCatalogPage.clickDeploy()
+      })
+    })
+
+    describe('Deploy wizard – Step 1: Specifications', () => {
+      it('Should select "Existing Fleet" as the target type', () => {
+        softwareCatalogPage.selectExistingFleetTarget()
+      })
+
+      it('Should click Next to proceed to fleet selection', () => {
+        softwareCatalogPage.clickWizardNext()
+      })
+    })
+
+    describe('Deploy wizard – Step 2: Select fleet', () => {
+      it('Should select the fleet created by the device simulator', () => {
+        softwareCatalogPage.selectFleetByName(CATALOG_FLEET_NAME)
+      })
+
+      it('Should click Next to proceed to review', () => {
+        softwareCatalogPage.clickWizardNext()
+      })
+    })
+
+    describe('Deploy wizard – Step 3: Review and deploy', () => {
+      it('Should click Deploy to apply the catalog item to the fleet', () => {
+        softwareCatalogPage.clickWizardDeploy()
+      })
+    })
+
+    describe('Post-deploy verification', () => {
+      it('Should show "Update configuration successful"', () => {
+        softwareCatalogPage.verifyUpdateSuccessful()
+      })
+
+      it('Should navigate to fleet details via "View fleet"', () => {
+        softwareCatalogPage.clickViewFleet()
+      })
+
+      it('Should open the Catalog tab on fleet details', () => {
+        softwareCatalogPage.clickFleetCatalogTab()
+      })
+
+      it('Should show the deployed catalog item under "Deployed Software"', () => {
+        softwareCatalogPage.verifyDeployedSoftware(getCatalogItemName())
+      })
+    })
+  })
+})

--- a/cypress/plugins/scaleFleetSimulatorTasks.js
+++ b/cypress/plugins/scaleFleetSimulatorTasks.js
@@ -82,7 +82,7 @@ function registerScaleFleetSimulatorTasks(on) {
      * Spawns the device simulator with fixed scale-demo arguments (50 devices, fleet label, concurrency 1).
      * If a simulator child is already running, returns `{ alreadyRunning: true }` instead of starting another.
      */
-    scaleFleetSimulatorStart() {
+    scaleFleetSimulatorStart({ count = 50, label = 'fleet=scale-fleet-00', initialDeviceIndex = 0 } = {}) {
       if (simulatorProcess && !simulatorProcess.killed) {
         return { alreadyRunning: true, pid: simulatorProcess.pid }
       }
@@ -98,12 +98,12 @@ function registerScaleFleetSimulatorTasks(on) {
       }
       const bin = getSimulatorBin()
       const args = [
-        '--count=50',
+        `--count=${count}`,
         '--label',
-        'fleet=scale-fleet-00',
+        label,
         '--log-level',
         'error',
-        '--initial-device-index=0',
+        `--initial-device-index=${initialDeviceIndex}`,
         '--max-concurrency',
         '10',
       ]

--- a/cypress/views/softwareCatalogPage.js
+++ b/cypress/views/softwareCatalogPage.js
@@ -1,0 +1,96 @@
+import { common } from './common'
+
+/** Fleet used by the software-catalog simulator run */
+export const CATALOG_FLEET_NAME = 'simulator-disk-monitoring'
+export const CATALOG_FLEET_LABEL_TEXT = `fleet=${CATALOG_FLEET_NAME}`
+
+/**
+ * Resolves the catalog item name created by the build-image test.
+ * Matches the convention in buildImagePage.cy.js: `${BUILD_NAME}-cin`.
+ */
+export const getCatalogItemName = () => {
+  const buildName = Cypress.env('buildName') || 'new-build-flightctl'
+  return `${buildName}-cin`
+}
+
+export const softwareCatalogPage = {
+  navigateTo: () => {
+    common.navigateTo('Software Catalog')
+  },
+
+  /**
+   * Click the catalog item card in the gallery to open the details drawer.
+   * The card uses `aria-label="Select <displayName>"` on its selectable action.
+   */
+  selectCatalogItem: (catalogItemName) => {
+    cy.get(`[aria-label="Select ${catalogItemName}"]`, { timeout: 30000 })
+      .should('be.visible')
+      .click()
+  },
+
+  /** Click the Deploy button in the catalog item details drawer. */
+  clickDeploy: () => {
+    cy.contains('button', 'Deploy').should('be.visible').click()
+  },
+
+  /**
+   * Select the "Existing Fleet" radio in the Specifications step.
+   * RadioField prefixes the id prop with "radiofield-", so id="fleet-radio"
+   * becomes id="radiofield-fleet-radio" in the DOM.
+   */
+  selectExistingFleetTarget: () => {
+    cy.get('#radiofield-fleet-radio', { timeout: 30000 }).should('exist')
+    cy.get('#radiofield-fleet-radio').click({ force: true })
+  },
+
+  /** Click the wizard Next button. */
+  clickWizardNext: () => {
+    cy.get('[data-testid="wizard-next-button"]').should('be.visible').click()
+  },
+
+  /**
+   * In the "Select fleet" table (wizard step 2), click the radio for the given fleet.
+   * PatternFly single-select tables render a radio <input> in the first column of each row.
+   */
+  selectFleetByName: (fleetName) => {
+    cy.contains('tr', fleetName, { timeout: 30000 })
+      .find('input[type="radio"]')
+      .click({ force: true })
+  },
+
+  /** Click the Deploy (save) button on the Review-and-deploy wizard step. */
+  clickWizardDeploy: () => {
+    cy.get('[data-testid="wizard-save-button"]').should('be.visible').click()
+  },
+
+  /** Verify the "Update configuration successful" success state. */
+  verifyUpdateSuccessful: () => {
+    cy.contains('Update configuration successful', { timeout: 30000 }).should('be.visible')
+  },
+
+  /** Click the "View fleet" link on the success page. */
+  clickViewFleet: () => {
+    cy.contains('button', 'View fleet').should('be.visible').click()
+  },
+
+  /**
+   * Click the "Catalog" tab on the fleet details page.
+   * PatternFly Tab renders as a <button role="tab">.
+   */
+  clickFleetCatalogTab: () => {
+    cy.contains('button[role="tab"]', 'Catalog', { timeout: 30000 })
+      .should('be.visible')
+      .click()
+  },
+
+  /**
+   * In the fleet details Catalog tab, verify the "Deployed Software" card shows
+   * the given catalog item name (displayName or metadata.name).
+   */
+  verifyDeployedSoftware: (catalogItemName) => {
+    cy.contains('Deployed Software', { timeout: 60000 }).should('be.visible')
+    cy.contains('Deployed Software')
+      .closest('.pf-v6-c-card')
+      .should('contain', catalogItemName)
+  },
+}


### PR DESCRIPTION
Adds a new softwareCatalogPage.cy.js spec that:
- Spins up 5 simulated devices on scale-fleet-01 via the device simulator
- Navigates to the Software Catalog, selects the catalog item published by the build-image test, and deploys it to the simulator fleet through the 3-step wizard (Specifications → Select fleet → Review and deploy)
- Verifies the "Update configuration successful" message and confirms the deployed catalog item appears under "Deployed Software" in the fleet's Catalog tab

Also extends scaleFleetSimulatorStart to accept optional count/label/ initialDeviceIndex params (non-breaking; existing tests pass no args), adds a buildName cypress env var, and introduces the softwareCatalogPage page object.