### PR TITLE
EDM-3946: Add device logs Cypress E2E tests

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress')
 const { downloadFile } = require('cypress-downloadfile/lib/addPlugin')
 const { registerScaleFleetSimulatorTasks } = require('./plugins/scaleFleetSimulatorTasks')
+const { registerFlightctlConsoleTasks } = require('./plugins/flightctlConsoleTasks')
 
 module.exports = defineConfig({
   video: true,
@@ -16,6 +17,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       on('task', { downloadFile })
       registerScaleFleetSimulatorTasks(on)
+      registerFlightctlConsoleTasks(on)
       // HTTPS oauth → http://localhost callback needs chromeWebSecurity off for the device-login spec
       // only; keep default true for other e2e specs.
       const norm = (p) => String(p).replace(/\\/g, '/')

--- a/cypress/e2e/device.cy.js
+++ b/cypress/e2e/device.cy.js
@@ -1,4 +1,4 @@
-import { devicesPage } from '../views/devicesPage'
+import { devicesPage, LOG_PRIORITIES } from '../views/devicesPage'
 
 describe('Device Management', () => {
   // One login + visit per spec file; later tests reuse the same tab (testIsolation: false).
@@ -44,7 +44,7 @@ describe('Device Management', () => {
     })
   })
 
-  describe('Approve device, edit device, view device events, decommission device', () => {
+  describe('Approve device, edit device, view device events', () => {
     it('Should approve a device enrollment request', () => {
       devicesPage.approveDevice()
     })
@@ -68,7 +68,98 @@ describe('Device Management', () => {
     it('Should view device events', () => {
       devicesPage.deviceEvents()
     })
+  })
 
+  describe('View device logs, filter by priority, search, download', () => {
+    const logMarker = (priority) => `CYPRESS_LOG_TEST_${priority.toUpperCase()}`
+
+    it('Should retrieve agent logs with default filters', () => {
+      devicesPage.openDeviceLogs()
+      devicesPage.retrieveLogsAndVerify()
+    })
+
+    it('Should retrieve system logs with default filters', () => {
+      devicesPage.selectLogCategory('System')
+      devicesPage.retrieveLogsAndVerify()
+    })
+
+    it('Should retrieve file path logs with default filters', () => {
+      devicesPage.selectLogCategory('File path')
+      cy.get('input[name="logFilePath"]', { timeout: 15000 }).clear().type('dnf.log')
+      devicesPage.retrieveLogsAndVerify()
+    })
+
+    it('Should show error for non-existing file path', () => {
+      devicesPage.openDeviceLogs()
+      devicesPage.selectLogCategory('File path')
+      cy.get('input[name="logFilePath"]', { timeout: 15000 }).clear().type('nonexistent-file-xyz.log')
+      cy.contains('button', 'Retrieve logs').should('not.be.disabled').click()
+      cy.get('.pf-m-danger, [class*="danger"]', { timeout: 30000 }).should('be.visible')
+    })
+
+    it('Should show error for directory file path', () => {
+      devicesPage.openDeviceLogs()
+      devicesPage.selectLogCategory('File path')
+      cy.get('input[name="logFilePath"]', { timeout: 15000 }).clear().type('audit')
+      cy.contains('button', 'Retrieve logs').should('not.be.disabled').click()
+      cy.get('.pf-m-danger, [class*="danger"]', { timeout: 30000 }).should('be.visible')
+    })
+
+    it('Should inject logger messages at each syslog priority', () => {
+      cy.task('flightctlConsoleCommand', {
+        commands: LOG_PRIORITIES.map(p => `logger -p user.${p.key} "${logMarker(p.key)}"`)
+      })
+    })
+
+    LOG_PRIORITIES.forEach(({ key, level }, index) => {
+      it(`Should show ${key} message and all higher priorities`, () => {
+        devicesPage.openDeviceLogs()
+        devicesPage.selectLogCategory('System')
+        devicesPage.selectLogTimeRange('Last 1 hour')
+        devicesPage.selectLogLevel(level)
+        devicesPage.retrieveLogsAndVerify()
+
+        LOG_PRIORITIES.slice(0, index + 1).forEach((p) => {
+          devicesPage.searchLogsFor(logMarker(p.key))
+        })
+      })
+    })
+
+    it('Should enable live logs and receive new entries', () => {
+      devicesPage.openDeviceLogs()
+      devicesPage.selectLogCategory('Agent')
+      devicesPage.selectLogTimeRange('Current boot')
+      devicesPage.retrieveLogsAndVerify()
+      cy.contains('Show live logs', { timeout: 15000 }).should('be.visible')
+      cy.get('.pf-v6-c-log-viewer__list-item', { timeout: 60000 }).its('length').then((initialCount) => {
+        cy.contains('Show live logs').click()
+        cy.get('.pf-v6-c-log-viewer__list-item', { timeout: 30000 })
+          .should('have.length.greaterThan', initialCount)
+      })
+    })
+
+    it('Should stop live streaming when toggled off', () => {
+      cy.contains('Show live logs').click()
+      cy.get('.pf-v6-c-log-viewer', { timeout: 5000 }).should('be.visible')
+    })
+
+    it('Should find and highlight search results', () => {
+      devicesPage.openDeviceLogs()
+      devicesPage.retrieveLogsAndVerify()
+      devicesPage.searchLogsFor('flightctl')
+    })
+
+    it('Should navigate between search results', () => {
+      cy.contains(/[1-9]\d*\s*\/\s*[1-9]\d*/).should('be.visible').then(($count) => {
+        const initialText = $count.text()
+        cy.wrap($count).parent().find('button').first().click()
+        cy.contains(/[1-9]\d*\s*\/\s*[1-9]\d*/).invoke('text').should('not.eq', initialText)
+      })
+    })
+
+  })
+
+  describe('Decommission device', () => {
     it('Should decommission a device', () => {
       devicesPage.decommissionDevice()
     })

--- a/cypress/plugins/flightctlConsoleTasks.js
+++ b/cypress/plugins/flightctlConsoleTasks.js
@@ -1,0 +1,62 @@
+/**
+ * Cypress tasks for running commands on enrolled devices via `flightctl console`.
+ * Requires `flightctl` CLI installed and logged in on the machine running Cypress.
+ *
+ * Usage in tests:
+ *   cy.task('flightctlConsoleCommand', {
+ *     commands: ['logger -p user.info "test message"', 'whoami']
+ *   })
+ */
+const { execSync } = require('child_process')
+const path = require('path')
+const os = require('os')
+const fs = require('fs')
+
+function getFlightctlBin() {
+  const fromEnv = process.env.CYPRESS_FLIGHTCTL_BIN
+  if (fromEnv) return fromEnv
+
+  const fromBuild = path.join(os.homedir(), 'flightctl', 'bin', 'flightctl')
+  if (fs.existsSync(fromBuild)) return fromBuild
+
+  return 'flightctl'
+}
+
+function getDeviceName(bin) {
+  try {
+    const output = execSync(`${bin} get devices -o json`, { encoding: 'utf-8', timeout: 15000 })
+    const devices = JSON.parse(output)
+    if (devices.items && devices.items.length > 0) {
+      return devices.items[0].metadata.name
+    }
+  } catch (e) { /* fall through */ }
+  return null
+}
+
+function registerFlightctlConsoleTasks(on) {
+  on('task', {
+    flightctlConsoleCommand({ commands }) {
+      const bin = getFlightctlBin()
+      const deviceName = getDeviceName(bin)
+      if (!deviceName) {
+        return [{ cmd: 'get devices', stdout: '', error: `No enrolled device found (using ${bin})` }]
+      }
+
+      const results = []
+      for (const cmd of commands) {
+        try {
+          const stdout = execSync(
+            `${bin} console dev/${deviceName} --notty -- ${cmd}`,
+            { encoding: 'utf-8', timeout: 15000 }
+          )
+          results.push({ cmd, stdout: stdout.trim(), error: null })
+        } catch (err) {
+          results.push({ cmd, stdout: err.stdout || '', error: err.message })
+        }
+      }
+      return results
+    },
+  })
+}
+
+module.exports = { registerFlightctlConsoleTasks }

--- a/cypress/views/devicesPage.js
+++ b/cypress/views/devicesPage.js
@@ -43,6 +43,32 @@ const FLEET_DEVICE_SELECTOR_LABELS = {
 /** Real `<input>` inside PatternFly TextInputGroup (`#typeahead-select-input` is the wrapper div). */
 const FLEET_LABEL_TYPEAHEAD_INPUT = '#typeahead-select-input input'
 
+/**
+ * Syslog priority levels mapped to their UI dropdown labels.
+ * Ordered by severity (highest first) — used for priority inclusivity tests:
+ * filtering at index N should show markers for all priorities 0..N.
+ */
+export const LOG_PRIORITIES = [
+  { key: 'emerg',   level: 'Only emergency' },
+  { key: 'alert',   level: 'Alert and above' },
+  { key: 'crit',    level: 'Critical and above' },
+  { key: 'err',     level: 'Error and above' },
+  { key: 'warning', level: 'Warning and above' },
+  { key: 'notice',  level: 'Notice and above' },
+  { key: 'info',    level: 'Info and above' },
+  { key: 'debug',   level: 'Debug and above' },
+]
+
+const LOGS_TAB = '[data-testid="device-details-tab-logs"]'
+const LOG_VIEWER = '.pf-v6-c-log-viewer'
+const LOG_VIEWER_LINE = '.pf-v6-c-log-viewer__list-item'
+const LOG_SEARCH_INPUT = 'input[placeholder="Search logs"]'
+const LOG_FILE_PATH_INPUT = 'input[name="logFilePath"]'
+const LOG_CATEGORY_TOGGLE = /^(Agent|System|File path)$/
+const LOG_TIME_RANGE_TOGGLE = /^(All time|Last 1 hour|Last 24 hours|Last 7 days|Current boot|Previous boot|Custom range)$/
+const LOG_LEVEL_TOGGLE = /All levels|and above|Only emergency/
+const LOG_RETRIEVE_TIMEOUT = 60000
+
 const enrolledDeviceRows = () =>
   cy.get('[data-testid="enrolled-devices-table"] tbody tr[data-testid^="enrolled-device-row-"]')
 
@@ -267,6 +293,52 @@ export const devicesPage = {
     cy.get('[data-testid="device-details-tab-terminal"]', { timeout: 30000 }).should('be.visible').click()
     cy.get('[data-testid="device-terminal-panel"]', { timeout: 50000 }).should('be.visible')
     cy.get('[data-testid="device-terminal-panel"]').click()
+  },
+
+  openDeviceLogs: (deviceName) => {
+    common.navigateTo('Devices')
+    if (deviceName) {
+      cy.contains(`[data-testid^="device-name-link-"]`, deviceName, { timeout: 15000 })
+        .should('be.visible').click()
+    } else {
+      cy.get(`[data-testid^="device-name-link-"]`, { timeout: 15000 })
+        .first().should('be.visible').click()
+    }
+    cy.get(LOGS_TAB, { timeout: 15000 }).should('be.visible').click()
+    cy.contains('button', 'Retrieve logs', { timeout: 15000 }).should('be.visible')
+  },
+
+  retrieveLogsAndVerify: () => {
+    cy.contains('button', 'Retrieve logs', { timeout: 15000 })
+      .should('be.visible')
+      .should('not.be.disabled')
+      .click()
+    cy.get(LOG_VIEWER, { timeout: LOG_RETRIEVE_TIMEOUT }).should('be.visible')
+    cy.get(LOG_VIEWER_LINE, { timeout: LOG_RETRIEVE_TIMEOUT })
+      .should('have.length.greaterThan', 0)
+  },
+
+  selectLogCategory: (category) => {
+    cy.contains('button', LOG_CATEGORY_TOGGLE, { timeout: 15000 })
+      .should('be.visible').click()
+    cy.get('[role="option"]').contains(category).click()
+  },
+
+  selectLogTimeRange: (label) => {
+    cy.contains('button', LOG_TIME_RANGE_TOGGLE, { timeout: 15000 })
+      .should('be.visible').click()
+    cy.get('[role="option"]').contains(label).click()
+  },
+
+  selectLogLevel: (label) => {
+    cy.contains('button', LOG_LEVEL_TOGGLE, { timeout: 15000 })
+      .should('be.visible').click()
+    cy.get('[role="option"]').contains(label).click()
+  },
+
+  searchLogsFor: (text) => {
+    cy.get(LOG_SEARCH_INPUT, { timeout: 10000 }).clear().type(text)
+    cy.contains(/[1-9]\d*\s*\/\s*[1-9]\d*/, { timeout: 10000 }).should('be.visible')
   },
 
   /** Leave decommissioned list and show enrolled devices (same switch data-testid on both tables). */


### PR DESCRIPTION
## Summary
- Add basic logs check tests for all 3 log types (agent, system, file path)
- Add system logs priority tests using `flightctl console` + `logger` to inject test messages at each syslog priority (emerg through debug), then verify each appears in the UI with the correct level filter
- Add `flightctlConsoleTasks` plugin for running commands on enrolled devices via `flightctl console`
- Add log-related page object methods to `devicesPage.js`
