### PR TITLE
fix: update status text from 'Accessible' to 'Available'

### DIFF
--- a/cypress/views/buildImagePage.js
+++ b/cypress/views/buildImagePage.js
@@ -112,7 +112,7 @@ export const buildImagePage = {
   submitRepositoryAndWaitForAccessible: () => {
     cy.get('[data-testid="repository-form-submit"]').should('be.visible').click()
     //cy.get('[data-testid="repository-details-sync-status"]', { timeout: 30000 })
-    //  .should('contain', 'Accessible')
+    //  .should('contain', 'Available')
   },
 
   // ── Wizard entry ───────────────────────────────────────────────────────────
@@ -148,7 +148,7 @@ export const buildImagePage = {
   },
 
   waitForImageAccessible: () => {
-    cy.contains('Accessible', { timeout: 30000 }).should('be.visible')
+    cy.contains('Available', { timeout: 30000 }).should('be.visible')
   },
 
   clickNext: () => {

--- a/cypress/views/repositoriesPage.js
+++ b/cypress/views/repositoriesPage.js
@@ -160,7 +160,7 @@ export const repositoriesPage = {
     cy.get('[data-testid="textfield-resourceSyncs[0].targetRevision"]').type(revision)
     cy.get('[data-testid="textfield-resourceSyncs[0].path"]').type(resource)
     cy.get('[data-testid="repository-form-submit"]').click()
-    cy.get('[data-testid="repository-details-sync-status"]', { timeout: 100000 }).should('contain', 'Accessible')
+    cy.get('[data-testid="repository-details-sync-status"]', { timeout: 100000 }).should('contain', 'Available')
   },
 
   /**
@@ -184,7 +184,7 @@ export const repositoriesPage = {
     cy.get('[data-testid="textfield-resourceSyncs[1].path"]').clear()
     cy.get('[data-testid="textfield-resourceSyncs[1].path"]').type(newyaml)
     cy.get('[data-testid="repository-form-submit"]').click()
-    cy.get('[data-testid="repository-details-sync-status"]', { timeout: 100000 }).should('contain', 'Accessible')
+    cy.get('[data-testid="repository-details-sync-status"]', { timeout: 100000 }).should('contain', 'Available')
   },
 
   /**


### PR DESCRIPTION
## Summary
- The FlightCtl UI changed the repository/image sync status label from **"Accessible"** to **"Available"**
- This caused Cypress test failures in `buildImagePage.js` and `repositoriesPage.js` because the assertions still expected the old `"Accessible"` text
- Updated all 4 occurrences (3 active assertions + 1 commented-out) to use `"Available"`

## Failing tests fixed
- `Build Image Page > Build New Image — Step 1: Base image > Should wait for "Accessible" status on the Image reference URL`
- `Repository Management > happy path > Should edit a repository`

## Test plan
- [ ] Re-run the `flightctl-cypress-test` Jenkins job and verify the two previously-failing tests now pass
- [ ] Verify the build image wizard completes successfully end-to-end

## CI failure reference
https://jenkins-csb-kniqe-ci.dno.corp.redhat.com/job/flightctl-cypress-test/477/testReport/

🤖 Generated with [Claude Code](https://claude.com/claude-code)