### PR TITLE
Vm app e2e

### DIFF
--- a/cypress/apps/kvm.yaml
+++ b/cypress/apps/kvm.yaml
@@ -1,0 +1,42 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: test-vm-yaml
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+              ports:
+                - port: 22
+          rng: {}
+        memory:
+          guest: 1024M
+        resources: {}
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:40
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              ssh_pwauth: true
+              password: fedora
+              chpasswd: { expire: False }

--- a/cypress/e2e/device.cy.js
+++ b/cypress/e2e/device.cy.js
@@ -1,5 +1,9 @@
 import { devicesPage, LOG_PRIORITIES } from '../views/devicesPage'
 
+const DEVICE_NAME = 'test-device'
+const DEVICE_NAME_EDITED = 'test-device-edited'
+const DEVICE_NAME_EDITED_2 = 'test-device-edited2'
+
 describe('Device Management', () => {
   // One login + visit per spec file; later tests reuse the same tab (testIsolation: false).
   before(() => {
@@ -44,29 +48,31 @@ describe('Device Management', () => {
     })
   })
 
-  describe('Approve device, edit device, view device events', () => {
+  describe('Approve device', () => {
     it('Should approve a device enrollment request', () => {
-      devicesPage.approveDevice()
+      devicesPage.approveDevice(DEVICE_NAME)
     })
 
     /* it('Should open a terminal on a device', () => {
       devicesPage.openTerminal()
     }) */
+  })
 
+  describe('Edit device, view device events', () => {
     it('Should edit a device', () => {
-      devicesPage.editDevice(`${Cypress.env('image')}`)
+      devicesPage.editDevice(`${Cypress.env('image')}`, DEVICE_NAME, DEVICE_NAME_EDITED)
     })
 
     it('Should edit a device image - fake url', () => {
-      devicesPage.editDevice(`quay.io/redhat/rhde:9.2`, 'test-device-edited', 'test-device-edited2')
+      devicesPage.editDevice(`quay.io/redhat/rhde:9.2`, DEVICE_NAME_EDITED, DEVICE_NAME_EDITED_2)
     })
 
     it('Should make sure device is out-of-date', () => {
-      devicesPage.checkDeviceOutOfDate()
+      devicesPage.checkDeviceOutOfDate(DEVICE_NAME_EDITED_2)
     })
 
     it('Should view device events', () => {
-      devicesPage.deviceEvents()
+      devicesPage.deviceEvents(DEVICE_NAME_EDITED_2)
     })
   })
 
@@ -74,7 +80,7 @@ describe('Device Management', () => {
     const logMarker = (priority) => `CYPRESS_LOG_TEST_${priority.toUpperCase()}`
 
     it('Should retrieve agent logs with default filters', () => {
-      devicesPage.openDeviceLogs()
+      devicesPage.openDeviceLogs(DEVICE_NAME_EDITED_2)
       devicesPage.retrieveLogsAndVerify()
     })
 
@@ -90,7 +96,7 @@ describe('Device Management', () => {
     })
 
     it('Should show error for non-existing file path', () => {
-      devicesPage.openDeviceLogs()
+      devicesPage.openDeviceLogs(DEVICE_NAME_EDITED_2)
       devicesPage.selectLogCategory('File path')
       cy.get('input[name="logFilePath"]', { timeout: 15000 }).clear().type('nonexistent-file-xyz.log')
       cy.contains('button', 'Retrieve logs').should('not.be.disabled').click()
@@ -98,7 +104,7 @@ describe('Device Management', () => {
     })
 
     it('Should show error for directory file path', () => {
-      devicesPage.openDeviceLogs()
+      devicesPage.openDeviceLogs(DEVICE_NAME_EDITED_2)
       devicesPage.selectLogCategory('File path')
       cy.get('input[name="logFilePath"]', { timeout: 15000 }).clear().type('audit')
       cy.contains('button', 'Retrieve logs').should('not.be.disabled').click()
@@ -107,13 +113,14 @@ describe('Device Management', () => {
 
     it('Should inject logger messages at each syslog priority', () => {
       cy.task('flightctlConsoleCommand', {
+        deviceAlias: DEVICE_NAME_EDITED_2,
         commands: LOG_PRIORITIES.map(p => `logger -p user.${p.key} "${logMarker(p.key)}"`)
       })
     })
 
     LOG_PRIORITIES.forEach(({ key, level }, index) => {
       it(`Should show ${key} message and all higher priorities`, () => {
-        devicesPage.openDeviceLogs()
+        devicesPage.openDeviceLogs(DEVICE_NAME_EDITED_2)
         devicesPage.selectLogCategory('System')
         devicesPage.selectLogTimeRange('Last 1 hour')
         devicesPage.selectLogLevel(level)
@@ -126,7 +133,7 @@ describe('Device Management', () => {
     })
 
     it('Should enable live logs and receive new entries', () => {
-      devicesPage.openDeviceLogs()
+      devicesPage.openDeviceLogs(DEVICE_NAME_EDITED_2)
       devicesPage.selectLogCategory('Agent')
       devicesPage.selectLogTimeRange('Current boot')
       devicesPage.retrieveLogsAndVerify()
@@ -144,7 +151,7 @@ describe('Device Management', () => {
     })
 
     it('Should find and highlight search results', () => {
-      devicesPage.openDeviceLogs()
+      devicesPage.openDeviceLogs(DEVICE_NAME_EDITED_2)
       devicesPage.retrieveLogsAndVerify()
       devicesPage.searchLogsFor('flightctl')
     })
@@ -161,7 +168,7 @@ describe('Device Management', () => {
 
   describe('Decommission device', () => {
     it('Should decommission a device', () => {
-      devicesPage.decommissionDevice()
+      devicesPage.decommissionDevice(DEVICE_NAME_EDITED_2)
     })
   })
 

--- a/cypress/e2e/deviceApps.cy.js
+++ b/cypress/e2e/deviceApps.cy.js
@@ -1,0 +1,36 @@
+import { devicesPage } from '../views/devicesPage'
+
+const DEVICE_APPS = 'test-apps'
+
+describe('Device applications (KVM)', () => {
+  before(() => {
+    // ACM console fires background uncaught exceptions during form navigation
+    // (e.g. findSectionHeaders in embedded console plugins). Same as buildImagePage.cy.js.
+    Cypress.on('uncaught:exception', () => false)
+    cy.ensureLoggedIn()
+  })
+
+  it('Should approve the apps device enrollment request', () => {
+    devicesPage.approveDevice(DEVICE_APPS)
+  })
+
+  it('Should add Form and YAML KVM apps via edit-device wizard and reach Running', { timeout: 720000 }, () => {
+    devicesPage.addApplications(DEVICE_APPS, [
+      { mode: 'form', name: 'test-vm', hostPort: '2222', guestPort: '22' },
+      { mode: 'yaml', name: 'test-vm-yaml', yaml: 'apps/kvm.yaml', hostPort: '2223', guestPort: '22' },
+    ])
+    devicesPage.waitForVmAppRunning(DEVICE_APPS, 'test-vm')
+    devicesPage.waitForVmAppRunning(DEVICE_APPS, 'test-vm-yaml')
+  })
+
+  it('Should open test-vm serial console and login as fedora', { timeout: 360000 }, () => {
+    devicesPage.openVmAppConsole(DEVICE_APPS, 'test-vm')
+    devicesPage.loginVmSerialConsole('fedora', 'fedora')
+    devicesPage.selectVmConsole('test-vm-yaml')
+    devicesPage.loginVmSerialConsole('fedora', 'fedora')
+  })
+
+  it('Should decommission the apps device', () => {
+    devicesPage.decommissionDevice(DEVICE_APPS)
+  })
+})

--- a/cypress/plugins/flightctlConsoleTasks.js
+++ b/cypress/plugins/flightctlConsoleTasks.js
@@ -4,6 +4,7 @@
  *
  * Usage in tests:
  *   cy.task('flightctlConsoleCommand', {
+ *     deviceAlias: 'test-device-edited2',
  *     commands: ['logger -p user.info "test message"', 'whoami']
  *   })
  */
@@ -55,12 +56,17 @@ function getFlightctlBin() {
   return 'flightctl'
 }
 
-function getDeviceName(bin) {
+function getDeviceName(bin, alias) {
   try {
     const output = execSync(`${bin} get devices -o json`, { encoding: 'utf-8', timeout: 15000 })
     const devices = JSON.parse(output)
-    if (devices.items && devices.items.length > 0) {
-      return devices.items[0].metadata.name
+    const items = devices.items || []
+    if (alias) {
+      const match = items.find((d) => d.metadata?.labels?.alias === alias)
+      if (match) return match.metadata.name
+    }
+    if (items.length > 0) {
+      return items[0].metadata.name
     }
   } catch (e) { /* fall through */ }
   return null
@@ -262,11 +268,12 @@ function registerFlightctlConsoleTasks(on) {
       return { seeded: true }
     },
 
-    flightctlConsoleCommand({ commands }) {
+    flightctlConsoleCommand({ commands, deviceAlias }) {
       const bin = getFlightctlBin()
-      const deviceName = getDeviceName(bin)
+      const deviceName = getDeviceName(bin, deviceAlias)
       if (!deviceName) {
-        return [{ cmd: 'get devices', stdout: '', error: `No enrolled device found (using ${bin})` }]
+        const hint = deviceAlias ? ` alias=${deviceAlias}` : ''
+        return [{ cmd: 'get devices', stdout: '', error: `No enrolled device found${hint} (using ${bin})` }]
       }
 
       const results = []

--- a/cypress/views/devicesPage.js
+++ b/cypress/views/devicesPage.js
@@ -17,6 +17,15 @@ const DEVICE_EVENTS_NORMAL = [
 /** Events list body on device details — Events tab */
 const EVENTS_CONTAINER = '[data-testid="device-events-list"]'
 
+/** Device details → Applications table (standalone UI expandable VM/apps table) */
+const DEVICE_APPLICATIONS_TABLE = '#fctl-applications-table'
+
+/** Device details → Terminal tab → VM serial console (Open console) */
+const APP_CONSOLE_TERMINAL = '[data-testid="app-console-terminal"]'
+const APP_CONSOLE_ERROR = '[data-testid="app-console-connect-error"]'
+const APP_CONSOLE_XTERM_ROWS = `${APP_CONSOLE_TERMINAL} .xterm-rows`
+const APP_CONSOLE_XTERM_INPUT = `${APP_CONSOLE_TERMINAL} .xterm-helper-textarea`
+
 /** RichValidationTextField validation button for approve modal alias */
 const DEVICE_ALIAS_VALIDATION_BTN = '[data-testid="rich-validation-field-deviceAlias-validation-button"]'
 
@@ -68,6 +77,130 @@ const LOG_CATEGORY_TOGGLE = /^(Agent|System|File path)$/
 const LOG_TIME_RANGE_TOGGLE = /^(All time|Last 1 hour|Last 24 hours|Last 7 days|Current boot|Previous boot|Custom range)$/
 const LOG_LEVEL_TOGGLE = /All levels|and above|Only emergency/
 const LOG_RETRIEVE_TIMEOUT = 60000
+
+const VM_APP_DEFAULTS = {
+  mode: 'form',
+  name: 'test-vm',
+  yaml: 'apps/kvm.yaml',
+  diskImage: 'quay.io/containerdisks/fedora:40',
+  memory: '1024M',
+  password: 'fedora',
+  hostPort: '2222',
+  guestPort: '22',
+}
+
+const vmAppFieldId = (index, field) => `textfield-applications[${index}].${field}`
+const vmAppSwitchId = (index, field) => `switchfield-applications[${index}].${field}`
+const vmAppSelectMenuId = (index, field) => `selectfield-applications[${index}].${field}-menu`
+
+const cdp = (command, params = {}) =>
+  Cypress.automation('remote:debugger:protocol', { command, params })
+
+const cdpCtrl = (key, code, vk) => {
+  const ctrl = 2
+  return cdp('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    key: 'Control',
+    code: 'ControlLeft',
+    windowsVirtualKeyCode: 17,
+    modifiers: ctrl,
+  })
+    .then(() =>
+      cdp('Input.dispatchKeyEvent', {
+        type: 'keyDown',
+        key,
+        code,
+        windowsVirtualKeyCode: vk,
+        modifiers: ctrl,
+      }),
+    )
+    .then(() =>
+      cdp('Input.dispatchKeyEvent', {
+        type: 'keyUp',
+        key,
+        code,
+        windowsVirtualKeyCode: vk,
+        modifiers: ctrl,
+      }),
+    )
+    .then(() =>
+      cdp('Input.dispatchKeyEvent', {
+        type: 'keyUp',
+        key: 'Control',
+        code: 'ControlLeft',
+        windowsVirtualKeyCode: 17,
+      }),
+    )
+}
+
+const pasteYamlIntoMonaco = (content) => {
+  cy.get('.fctl-yaml-editor .monaco-editor', { timeout: 30000 }).scrollIntoView({ block: 'center' }).click({ force: true })
+  cy.get('.fctl-yaml-editor textarea').click({ force: true })
+  cy.window().then((win) => {
+    win.focus()
+    return cdp('Page.bringToFront')
+      .catch(() => undefined)
+      .then(() =>
+        cdp('Browser.grantPermissions', {
+          permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+          origin: win.location.origin,
+        }),
+      )
+      .catch(() => undefined)
+      .then(() => win.navigator.clipboard.writeText(content))
+  })
+  cy.then(() => cdpCtrl('a', 'KeyA', 65))
+  cy.then(() => cdpCtrl('v', 'KeyV', 86))
+  cy.get('.fctl-yaml-editor .view-lines').invoke('text').should('not.be.empty')
+}
+
+const addVmApplication = (index, app = {}) => {
+  const vmApp = { ...VM_APP_DEFAULTS, ...app }
+  const fieldId = (field) => vmAppFieldId(index, field)
+  const typeMenu = `[id="${vmAppSelectMenuId(index, 'appType')}"]`
+
+  cy.get('body').then(($body) => {
+    if ($body.find(typeMenu).length === 0) {
+      cy.contains('button', 'Add application').scrollIntoView().click({ force: true })
+    }
+  })
+  cy.get(typeMenu, { timeout: 15000 }).scrollIntoView({ block: 'center' }).click({ force: true })
+  cy.contains('[role="option"]', 'Virtual machine (KVM)').click()
+  cy.get(`[id="${fieldId('name')}"]`).scrollIntoView({ block: 'center' }).clear({ force: true }).type(vmApp.name, { force: true })
+
+  if (vmApp.mode === 'yaml') {
+    cy.get(`[id="applications[${index}]-yaml-mode"]`).click({ force: true })
+    cy.readFile(vmApp.yaml).then((yaml) => {
+      const content = yaml.replace(/(metadata:\s*\n\s*name:\s*).+/, `$1${vmApp.name}`)
+      pasteYamlIntoMonaco(content)
+    })
+  } else {
+    cy.get(`[id="${fieldId('diskImage')}"]`).clear({ force: true }).type(vmApp.diskImage, { force: true })
+    cy.get(`[id="${fieldId('memory')}"]`).clear({ force: true }).type(vmApp.memory, { force: true })
+    cy.get(`[id="${vmAppSwitchId(index, 'enablePassword')}"]`).click({ force: true })
+    cy.get(`[id="${fieldId('password')}"]`).clear({ force: true }).type(vmApp.password, { force: true, log: false })
+  }
+
+  if (vmApp.hostPort && vmApp.guestPort) {
+    const appSectionAnchor =
+      vmApp.mode === 'yaml'
+        ? `[id="applications[${index}]-yaml-mode"]`
+        : `[id="${fieldId('name')}"]`
+    cy.get(appSectionAnchor)
+      .closest('.pf-v6-c-expandable-section, .pf-c-expandable-section')
+      .scrollIntoView({ block: 'center' })
+      .within(() => {
+        cy.contains('Map ports from inside the VM to the host device')
+          .closest('.pf-v6-c-form__group, .pf-c-form__group')
+          .within(() => {
+            cy.get('input').eq(0).clear({ force: true }).type(vmApp.hostPort, { force: true })
+            cy.get('input[aria-label="VM port"]').clear({ force: true }).type(vmApp.guestPort, { force: true })
+            cy.contains('button', /^Add$/).should('not.be.disabled').click({ force: true })
+          })
+        cy.contains(`${vmApp.hostPort}:${vmApp.guestPort}/tcp`).should('exist')
+      })
+  }
+}
 
 const enrolledDeviceRows = () =>
   cy.get('[data-testid="enrolled-devices-table"] tbody tr[data-testid^="enrolled-device-row-"]')
@@ -128,6 +261,15 @@ const clickEnrolledDeviceNameLinkAcrossPages = (deviceRef, pagesLeft = 8) => {
   })
 }
 
+/** Enrolled-table row by alias. Callers should chain .scrollIntoView() before interacting. */
+const enrolledDeviceRowByAlias = (deviceName, timeout = 60000) =>
+  cy.contains('[data-testid="enrolled-devices-table"] tr', deviceName, { timeout })
+
+const enrolledDeviceLinkByAlias = (deviceName, timeout = 60000) =>
+  enrolledDeviceRowByAlias(deviceName, timeout)
+    .scrollIntoView({ block: 'center' })
+    .find(`[data-testid^="device-name-link-"]`)
+
 /**
  * DevicesPage object for device management operations.
  * Prefer data-testid selectors from flightctl-ui for stability.
@@ -135,7 +277,7 @@ const clickEnrolledDeviceNameLinkAcrossPages = (deviceRef, pagesLeft = 8) => {
 export const devicesPage = {
   openApproveDeviceModal: () => {
     common.navigateTo('Devices')
-    cy.get('[data-testid="list-page-title"]').contains('Devices pending approval')
+    cy.get('[data-testid="list-page-title"]').should('contain', 'Devices pending approval')
     cy.get(`[data-testid="enrollment-request-approve-button-${ROW_0}"]`).should('exist')
     cy.get(`[data-testid="enrollment-request-approve-button-${ROW_0}"]`).should('be.visible')
     cy.get(`[data-testid="enrollment-request-approve-button-${ROW_0}"]`).click()
@@ -160,24 +302,25 @@ export const devicesPage = {
 
   approveDevice: (deviceName = 'test-device') => {
     common.navigateTo('Devices')
-
-    cy.get('[data-testid="list-page-title"]').contains('Devices pending approval')
-    cy.get(`[data-testid="enrollment-request-approve-button-${ROW_0}"]`).should('exist')
-    cy.get(`[data-testid="enrollment-request-approve-button-${ROW_0}"]`).should('be.visible')
-    cy.get(`[data-testid="enrollment-request-approve-button-${ROW_0}"]`).click()
+    cy.get('[data-testid="list-page-title"]', { timeout: 500000 }).should('contain', 'Devices pending approval')
+    cy.contains('.fctl-resource-link__text', new RegExp(`^${deviceName}$`), { timeout: 500000 })
+      .scrollIntoView({ block: 'center' })
+      .closest('tr')
+      .find('[data-testid^="enrollment-request-approve-button-"]')
+      .click()
     cy.get('[data-testid="rich-validation-field-deviceAlias"]').should('be.visible')
     cy.get('[data-testid="rich-validation-field-deviceAlias"]').clear()
     cy.get('[data-testid="rich-validation-field-deviceAlias"]').type(deviceName)
     cy.get('[data-testid="rich-validation-field-deviceAlias"]').should('have.value', deviceName)
     cy.get('[data-testid="approve-device-form-submit"]').should('be.visible')
     cy.get('[data-testid="approve-device-form-submit"]').click()
-    cy.get(`[data-testid="enrolled-device-row-${ROW_0}"]`, { timeout: 500000 }).should('contain', 'Online')
+    enrolledDeviceRowByAlias(deviceName, 500000).should('contain', 'Online')
   },
 
   deviceEvents: (deviceName = 'test-device') => {
     common.navigateTo('Devices')
     cy.wait(1000)
-    cy.contains(`[data-testid^="device-name-link-"]`, deviceName).should('be.visible').click()
+    enrolledDeviceLinkByAlias(deviceName).click()
     cy.wait(1000)
     cy.get('[data-testid="device-details-tab-events"]').should('be.visible').click()
     cy.wait(1000)
@@ -209,9 +352,8 @@ export const devicesPage = {
   editDevice: (image, currentName = 'test-device', newName = 'test-device-edited') => {
     common.navigateTo('Devices')
 
-    cy.contains(`[data-testid^="device-name-link-"]`, currentName).should('be.visible')
-    cy.contains(`[data-testid^="device-name-link-"]`, currentName)
-      .closest('tr')
+    enrolledDeviceRowByAlias(currentName)
+      .scrollIntoView({ block: 'center' })
       .find(`[data-testid^="device-row-actions-"] .pf-v6-c-menu-toggle`)
       .click()
     cy.wait(1000)
@@ -234,7 +376,7 @@ export const devicesPage = {
 
   checkDeviceOutOfDate: (deviceName = 'test-device-edited2') => {
     common.navigateTo('Devices')
-    cy.contains(`[data-testid^="device-name-link-"]`, deviceName).should('be.visible')
+    enrolledDeviceLinkByAlias(deviceName)
 
     const intervalMs = 5000
     const totalMs = 120000
@@ -244,39 +386,43 @@ export const devicesPage = {
       if (attempt > 0) {
         cy.wait(intervalMs)
       }
-      cy.get('[data-testid="enrolled-devices-table"]').then(($table) => {
-        const found = Cypress.$.makeArray($table.find('[data-testid^="device-update-status-"]')).some((el) =>
-          el.textContent.includes('Out-of-date'),
-        )
-        if (found) {
-          cy.get('[data-testid="enrolled-devices-table"]')
-            .find('[data-testid^="device-update-status-"]')
-            .contains('Out-of-date')
-            .should('be.visible')
-        } else if (attempt + 1 < maxAttempts) {
-          pollForOutOfDate(attempt + 1)
-        } else {
-          throw new Error(
-            `Update status did not contain "Out-of-date" within ${totalMs / 1000}s (checked every ${intervalMs / 1000}s)`,
-          )
-        }
-      })
+      enrolledDeviceRowByAlias(deviceName)
+        .then(($tr) => {
+          const found = $tr.find('[data-testid^="device-update-status-"]').text().includes('Out-of-date')
+          if (found) {
+            cy.wrap($tr)
+              .find('[data-testid^="device-update-status-"]')
+              .contains('Out-of-date')
+              .should('be.visible')
+          } else if (attempt + 1 < maxAttempts) {
+            pollForOutOfDate(attempt + 1)
+          } else {
+            throw new Error(
+              `Update status did not contain "Out-of-date" within ${totalMs / 1000}s (checked every ${intervalMs / 1000}s)`,
+            )
+          }
+        })
     }
     pollForOutOfDate(0)
   },
 
-  decommissionDevice: () => {
+  decommissionDevice: (deviceName = 'test-device-edited2') => {
     common.navigateTo('Devices')
 
-    cy.get(`[data-testid="enrolled-device-row-${ROW_0}"]`).find('input[type="checkbox"]').should('be.visible')
-    cy.get(`[data-testid="enrolled-device-row-${ROW_0}"]`).find('input[type="checkbox"]').click()
+    enrolledDeviceRowByAlias(deviceName)
+      .scrollIntoView({ block: 'center' })
+      .find('input[type="checkbox"]')
+      .should('be.visible')
+      .click()
     cy.get('[data-testid="toolbar-decommission-devices"]').should('be.visible')
     cy.get('[data-testid="toolbar-decommission-devices"]').click()
     cy.get('[data-testid="modal-decommission-confirm"]').should('be.visible')
     cy.get('[data-testid="modal-decommission-confirm"]').click()
-    cy.get('[data-testid="toolbar-delete-forever"]').should('be.visible')
-    cy.get('table thead input[type="checkbox"]').should('be.visible')
-    cy.get('table thead input[type="checkbox"]').click()
+    cy.get('[data-testid="decommissioned-devices-table"]').should('exist')
+    cy.get('[data-testid="decommissioned-devices-table"] thead input[type="checkbox"]')
+      .scrollIntoView({ block: 'center' })
+      .should('be.visible')
+      .click()
     cy.get('[data-testid="toolbar-delete-forever"]').should('be.visible')
     cy.get('[data-testid="toolbar-delete-forever"]').click()
     cy.get('[data-testid="modal-delete-devices-confirm"]').should('be.visible')
@@ -288,8 +434,7 @@ export const devicesPage = {
   openTerminal: (deviceName = 'test-device') => {
     common.navigateTo('Devices')
 
-    cy.contains(`[data-testid^="device-name-link-"]`, deviceName).should('be.visible')
-    cy.contains(`[data-testid^="device-name-link-"]`, deviceName).click()
+    enrolledDeviceLinkByAlias(deviceName).click()
     cy.get('[data-testid="device-details-tab-terminal"]', { timeout: 30000 }).should('be.visible').click()
     cy.get('[data-testid="device-terminal-panel"]', { timeout: 50000 }).should('be.visible')
     cy.get('[data-testid="device-terminal-panel"]').click()
@@ -298,11 +443,13 @@ export const devicesPage = {
   openDeviceLogs: (deviceName) => {
     common.navigateTo('Devices')
     if (deviceName) {
-      cy.contains(`[data-testid^="device-name-link-"]`, deviceName, { timeout: 15000 })
-        .should('be.visible').click()
+      enrolledDeviceLinkByAlias(deviceName, 15000).click()
     } else {
       cy.get(`[data-testid^="device-name-link-"]`, { timeout: 15000 })
-        .first().should('be.visible').click()
+        .first()
+        .scrollIntoView({ block: 'center' })
+        .should('be.visible')
+        .click()
     }
     cy.get(LOGS_TAB, { timeout: 15000 }).should('be.visible').click()
     cy.contains('button', 'Retrieve logs', { timeout: 15000 }).should('be.visible')
@@ -539,5 +686,103 @@ export const devicesPage = {
   addFleetLabelOnDeviceDetails: (labelText = SCALE_FLEET_LABEL_TEXT) => {
     cy.contains('button', 'Add label').click()
     cy.get('input[aria-label="New label"]').clear().type(`${labelText}{enter}`)
+  },
+
+  openEditDeviceConfigurations: (deviceName) => {
+    common.navigateTo('Devices')
+    enrolledDeviceRowByAlias(deviceName)
+      .scrollIntoView({ block: 'center' })
+      .find(`[data-testid^="device-row-actions-"] .pf-v6-c-menu-toggle`)
+      .click()
+    cy.contains('Edit device configurations').click()
+    cy.contains('h1', 'Edit device').should('be.visible')
+    cy.get('[data-testid="wizard-next-button"]').should('be.visible')
+  },
+
+  addApplications: (deviceName, apps) => {
+    devicesPage.openEditDeviceConfigurations(deviceName)
+    cy.get('[data-testid="wizard-next-button"]').click()
+    apps.forEach((app, index) => {
+      addVmApplication(index, app)
+    })
+    cy.get('[data-testid="wizard-next-button"]').click()
+    cy.get('[data-testid="wizard-next-button"]').click()
+    cy.get('[data-testid="wizard-save-button"]').click()
+    cy.get('[data-testid="device-details-title"]', { timeout: 120000 }).should('contain', deviceName)
+  },
+
+  waitForVmAppRunning: (deviceName = 'test-device', appName = 'test-vm', timeoutMs = 600000) => {
+    cy.get('[data-testid="device-details-title"]', { timeout: 30000 }).should('contain', deviceName)
+    cy.get(DEVICE_APPLICATIONS_TABLE, { timeout: timeoutMs }).scrollIntoView({ block: 'center' })
+    cy.get(DEVICE_APPLICATIONS_TABLE)
+      .find('td[data-label="Name"]')
+      .contains(new RegExp(`^${appName}$`), { timeout: timeoutMs })
+      .parents('tr')
+      .find('td[data-label="Status"]', { timeout: timeoutMs })
+      .should('contain', 'Running')
+  },
+
+  openVmAppConsole: (deviceName = 'test-device', appName = 'test-vm') => {
+    common.navigateTo('Devices')
+    enrolledDeviceLinkByAlias(deviceName).click()
+    cy.get('[data-testid="device-details-title"]').should('contain', deviceName)
+    cy.get(DEVICE_APPLICATIONS_TABLE).scrollIntoView({ block: 'center' })
+    cy.get(DEVICE_APPLICATIONS_TABLE)
+      .find('td[data-label="Name"]')
+      .contains(new RegExp(`^${appName}$`))
+      .parents('tr')
+      .as('vmAppRow')
+    cy.get('@vmAppRow').find('button[aria-label="Details"]').then(($btn) => {
+      if ($btn.attr('aria-expanded') !== 'true') {
+        cy.wrap($btn).click()
+      }
+    })
+    cy.get('@vmAppRow').next('tr').contains('button', 'Open console').should('not.be.disabled').click()
+    cy.get('[data-testid="device-terminal-panel"]', { timeout: 30000 }).should('be.visible')
+    cy.get(`${APP_CONSOLE_TERMINAL}, ${APP_CONSOLE_ERROR}`, { timeout: 90000 }).should('be.visible')
+    cy.get('body').then(($body) => {
+      if ($body.find(APP_CONSOLE_ERROR).length) {
+        cy.contains('End active session').click()
+        cy.contains('End session and connect').click()
+      }
+    })
+    cy.get(APP_CONSOLE_TERMINAL, { timeout: 60000 }).should('be.visible')
+    cy.get(APP_CONSOLE_XTERM_ROWS, { timeout: 30000 }).invoke('text').should('include', 'Connected to serial console')
+  },
+
+  selectVmConsole: (appName) => {
+    cy.get('[data-testid="device-terminal-panel"] .pf-v6-c-menu-toggle').click()
+    cy.contains('[role="option"]', appName).click()
+    cy.get(`${APP_CONSOLE_TERMINAL}, ${APP_CONSOLE_ERROR}`, { timeout: 90000 }).should('be.visible')
+    cy.get('body').then(($body) => {
+      if ($body.find(APP_CONSOLE_ERROR).length) {
+        cy.contains('End active session').click()
+        cy.contains('End session and connect').click()
+      }
+    })
+    cy.get(APP_CONSOLE_TERMINAL, { timeout: 60000 }).should('be.visible')
+    cy.get(APP_CONSOLE_XTERM_ROWS, { timeout: 30000 })
+      .invoke('text')
+      .should('include', `Connected to serial console: ${appName}`)
+  },
+
+  loginVmSerialConsole: (user = 'fedora', password = 'fedora') => {
+    cy.get(APP_CONSOLE_XTERM_INPUT, { timeout: 30000 }).should('exist').click({ force: true }).type('{enter}', { force: true })
+    cy.get(APP_CONSOLE_XTERM_ROWS, { timeout: 120000 }).should(($el) => {
+      expect($el.text()).to.match(/login:/i)
+    })
+    cy.get(APP_CONSOLE_XTERM_INPUT).click({ force: true }).type(`${user}{enter}`, { force: true, delay: 50 })
+    cy.get(APP_CONSOLE_XTERM_ROWS, { timeout: 30000 }).should(($el) => {
+      expect($el.text()).to.match(/Password:/i)
+    })
+    cy.get(APP_CONSOLE_XTERM_INPUT).type(`${password}{enter}`, { force: true, delay: 50, log: false })
+    cy.get(APP_CONSOLE_XTERM_INPUT).type('{enter}', { force: true })
+    cy.get(APP_CONSOLE_XTERM_ROWS, { timeout: 60000 }).should(($el) => {
+      expect($el.text()).to.match(new RegExp(`${user}@`))
+    })
+    cy.get(APP_CONSOLE_XTERM_INPUT).type('whoami{enter}', { force: true, delay: 50 })
+    cy.get(APP_CONSOLE_XTERM_ROWS, { timeout: 30000 }).should(($el) => {
+      expect($el.text()).to.match(new RegExp(`whoami[\\s\\S]*${user}`))
+    })
   },
 }


### PR DESCRIPTION
## Summary
- Adds `deviceApps.cy.js` for Form + YAML KVM apps and serial console login against alias `test-apps` (device6).
- Restores `device.cy.js` lifecycle on `test-device` (approve, edit, logs, decommission, scale fleet).
- Approve / decommission / `flightctl console` target devices by alias so both VMs can coexist.

## Test plan
- [x] With only device5 enrolled as `test-device`, `device.cy.js` still covers the original flow.
- [x] After device6 is pending as `test-apps`, run `npx cypress run --spec e2e/deviceApps.cy.js`.
- [x] Confirm decommission of `test-device-edited2` does not delete `test-apps`.